### PR TITLE
Fix thermo test fail

### DIFF
--- a/oscps-gui/Cargo.toml
+++ b/oscps-gui/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "oscps-gui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+iced = "0.13.1"

--- a/oscps-gui/src/main.rs
+++ b/oscps-gui/src/main.rs
@@ -1,0 +1,32 @@
+#[derive(Default)]
+struct Counter {
+    value: i8,
+}
+#[derive(Debug, Clone, Copy)]
+pub enum Message {
+    Increment,
+    Decrement,
+}
+use iced::widget::{button, row, text, Row};
+impl Counter {
+    pub fn view(&self) -> Row<Message> {
+        row![
+            button("+").on_press(Message::Increment),
+            text(self.value).size(50),
+            button("-").on_press(Message::Decrement),
+        ]
+    }
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::Increment => {
+                self.value += 1;
+            }
+            Message::Decrement => {
+                self.value -= 1;
+            }
+        }
+    }
+}
+fn main() -> iced::Result {
+    iced::run("A cool counter", Counter::update, Counter::view)
+}

--- a/oscps-lib/src/component.rs
+++ b/oscps-lib/src/component.rs
@@ -8,24 +8,6 @@ extern crate pubchem;
 use anyhow::Result;
 use std::{thread,time::Duration};
 
-// pub enum RequestStatusCodes {
-//     BadRequest,
-//     NotFound,
-//     GatewayError,
-//     Success
-
-// }
-
-// impl RequestStatusCodes {
-//     pub fn value(&self) -> u32 {
-//         match self {
-//             RequestStatusCodes::Success => 200,
-//             RequestStatusCodes::NotFound => 404,
-//             RequestStatusCodes::GatewayError => 504,
-//             RequestStatusCodes::BadRequest => 400
-//         }
-//     }
-// }
 
 #[allow(dead_code)]
 /// This will hold the list of chemicals used within the simulation

--- a/oscps-lib/src/component.rs
+++ b/oscps-lib/src/component.rs
@@ -6,6 +6,26 @@ extern crate uom;
 
 extern crate pubchem;
 use anyhow::Result;
+use std::{thread,time::Duration};
+
+// pub enum RequestStatusCodes {
+//     BadRequest,
+//     NotFound,
+//     GatewayError,
+//     Success
+
+// }
+
+// impl RequestStatusCodes {
+//     pub fn value(&self) -> u32 {
+//         match self {
+//             RequestStatusCodes::Success => 200,
+//             RequestStatusCodes::NotFound => 404,
+//             RequestStatusCodes::GatewayError => 504,
+//             RequestStatusCodes::BadRequest => 400
+//         }
+//     }
+// }
 
 #[allow(dead_code)]
 /// This will hold the list of chemicals used within the simulation
@@ -43,9 +63,23 @@ impl Chemical {
             ChemicalIdentifier::PubchemID(id) => pubchem::Compound::new(id),
             ChemicalIdentifier::CompoundName(name) => pubchem::Compound::with_name(name.as_str()),
         };
+        let mut request_counter = 0;
+        let mut cid_vec = None;
+        while request_counter <= 10 {
+            match pubchem_chemical_object.cids(){
+                Ok(cid_list) => {
+                    cid_vec = Some(cid_list);
+                    break;
+                },
+                _ => {
+                    request_counter = request_counter + 1;
+                    thread::sleep(Duration::from_secs(10));
+                }
+            };
+        }
 
-        let cid_vec = pubchem_chemical_object.cids().unwrap();
-        let cid: i32 = cid_vec[0];
+        // let cid_vec = pubchem_chemical_object.cids().unwrap();
+        let cid: i32 = cid_vec.unwrap()[0];
         let prop = ChemicalProperties::new(cid).unwrap();
         return Ok(Chemical {
             pubchem_obj: pubchem_chemical_object,
@@ -93,6 +127,7 @@ impl ChemicalProperties {
 #[cfg(test)]
 mod chemical_species_tests {
     use crate::component::{Chemical, ChemicalIdentifier};
+    use std::{thread,time::Duration};
 
     #[test]
     fn test_create_chemical_from_pubchem_id() {
@@ -100,7 +135,8 @@ mod chemical_species_tests {
         let identifier = ChemicalIdentifier::PubchemID(7732);
 
         let chemical = Chemical::new(identifier);
-
+        thread::sleep(Duration::from_secs(10));
+        
         assert!(
             chemical.is_ok(),
             "Failed to create chemical from PubChem ID"
@@ -119,6 +155,8 @@ mod chemical_species_tests {
         let identifier = ChemicalIdentifier::CompoundName(String::from("Water"));
 
         let chemical = Chemical::new(identifier);
+        thread::sleep(Duration::from_secs(10));
+
 
         assert!(chemical.is_ok(), "Failed to create chemical from name");
         let chemical = chemical.unwrap();

--- a/oscps-lib/src/thermodynamics.rs
+++ b/oscps-lib/src/thermodynamics.rs
@@ -91,7 +91,7 @@ impl ThermoState {
         ThermoState {
             pressure: Pressure::new::<pascal>(pressure),
             temperature: ThermodynamicTemperature::new::<kelvin>(temperature),
-            mass_list: mass_list,
+            mass_list,
         }
     }
 
@@ -161,15 +161,17 @@ mod thermo_tests {
         assert_eq!(thermo_state.temperature.get::<kelvin>(), 298.15);
         assert_eq!(thermo_state.mass_list.len(), 1); // Should contain one mole fraction entry
 
+        
+
         // Check that the mole fraction's chemical is correctly set
-        assert_eq!(
-            thermo_state.mass_list[0]
-                .chemical_species
-                .get_pubchem_obj()
-                .cids()
-                .unwrap()[0],
-            962
-        );
+        // assert_eq!(
+        //     thermo_state.mass_list[0]
+        //         .chemical_species
+        //         .get_pubchem_obj()
+        //         .cids()
+        //         .unwrap()[0],
+        //     962
+        // );
     }
 
     #[test]
@@ -216,9 +218,9 @@ mod thermo_tests {
             .mass_frac(&therm_obj.mass_list[0].chemical_species)
             .unwrap();
 
-        assert!(
-            (mass_fraction - 0.2).abs() < 1e-6,
-            "Mole fraction calculation failed"
-        ); // Should be 0.2
+        // assert!(
+        //     (mass_fraction - 0.2).abs() < 1e-6,
+        //     "Mole fraction calculation failed"
+        // ); // Should be 0.2
     }
 }

--- a/oscps-lib/src/thermodynamics.rs
+++ b/oscps-lib/src/thermodynamics.rs
@@ -132,6 +132,7 @@ mod thermo_tests {
     use uom::si::mass::kilogram;
     use uom::si::pressure::pascal;
     use uom::si::thermodynamic_temperature::kelvin;
+    use std::{thread,time::Duration};
 
     #[test]
     ///Test case generates an instance of the 'ThermoState' struct
@@ -146,6 +147,7 @@ mod thermo_tests {
                 acentric_factor: 0.344,    // example
             },
         };
+        thread::sleep(Duration::from_secs(10));
         let water_mass = Mass::new::<kilogram>(2.0);
         let water_species_pair = SpeciesListPair {
             chemical_species: water,
@@ -167,14 +169,14 @@ mod thermo_tests {
         
 
         // Check that the mole fraction's chemical is correctly set
-        // assert_eq!(
-        //     thermo_state.mass_list[0]
-        //         .chemical_species
-        //         .get_pubchem_obj()
-        //         .cids()
-        //         .unwrap()[0],
-        //     962
-        // );
+        assert_eq!(
+            thermo_state.mass_list[0]
+                .chemical_species
+                .get_pubchem_obj()
+                .cids()
+                .unwrap()[0],
+            962
+        );
     }
 
     #[test]
@@ -189,6 +191,7 @@ mod thermo_tests {
                 acentric_factor: 0.344,    // example
             },
         };
+        thread::sleep(Duration::from_secs(10));
 
         let anisdine = Chemical {
             pubchem_obj: pubchem::Compound::new(7732),
@@ -199,7 +202,8 @@ mod thermo_tests {
                 acentric_factor: 0.24,    // (approximated)
             },
         };
-
+        thread::sleep(Duration::from_secs(10));
+        
         let water_mass = Mass::new::<kilogram>(2.0);
         let water_species_pair = SpeciesListPair {
             chemical_species: water,
@@ -222,9 +226,9 @@ mod thermo_tests {
             .mass_frac(&therm_obj.mass_list[0].chemical_species)
             .unwrap();
 
-        // assert!(
-        //     (mass_fraction - 0.2).abs() < 1e-6,
-        //     "Mole fraction calculation failed"
-        // ); // Should be 0.2
+        assert!(
+            (mass_fraction - 0.2).abs() < 1e-6,
+            "Mole fraction calculation failed"
+        ); // Should be 0.2
     }
 }

--- a/oscps-lib/src/thermodynamics.rs
+++ b/oscps-lib/src/thermodynamics.rs
@@ -132,6 +132,7 @@ mod thermo_tests {
     use uom::si::thermodynamic_temperature::kelvin;
 
     #[test]
+    #[allow(dead_code)]
     fn test_create_thermo_state() {
         // Create some test data for ThermoMoleFrac (mole fractions)
         let water = Chemical {
@@ -159,9 +160,7 @@ mod thermo_tests {
         // Validate ThermoState
         assert_eq!(thermo_state.pressure.get::<pascal>(), 101325.0);
         assert_eq!(thermo_state.temperature.get::<kelvin>(), 298.15);
-        assert_eq!(thermo_state.mass_list.len(), 1); // Should contain one mole fraction entry
-
-        
+        assert_eq!(thermo_state.mass_list.len(), 1); // Should contain one mole fraction entry 
 
         // Check that the mole fraction's chemical is correctly set
         // assert_eq!(
@@ -208,15 +207,15 @@ mod thermo_tests {
             mass_quantity: anisidine_mass,
         };
 
-        let therm_obj = ThermoState::new(
+        let _therm_obj = ThermoState::new(
             101325.0,
             298.15,
             vec![water_species_pair, anisidine_species_pair],
         );
 
-        let mass_fraction = therm_obj
-            .mass_frac(&therm_obj.mass_list[0].chemical_species)
-            .unwrap();
+        // let mass_fraction = _therm_obj
+        //     .mass_frac(&_therm_obj.mass_list[0].chemical_species)
+        //     .unwrap();
 
         // assert!(
         //     (mass_fraction - 0.2).abs() < 1e-6,

--- a/oscps-lib/src/thermodynamics.rs
+++ b/oscps-lib/src/thermodynamics.rs
@@ -132,7 +132,6 @@ mod thermo_tests {
     use uom::si::thermodynamic_temperature::kelvin;
 
     #[test]
-    #[allow(dead_code)]
     fn test_create_thermo_state() {
         // Create some test data for ThermoMoleFrac (mole fractions)
         let water = Chemical {
@@ -160,7 +159,9 @@ mod thermo_tests {
         // Validate ThermoState
         assert_eq!(thermo_state.pressure.get::<pascal>(), 101325.0);
         assert_eq!(thermo_state.temperature.get::<kelvin>(), 298.15);
-        assert_eq!(thermo_state.mass_list.len(), 1); // Should contain one mole fraction entry 
+        assert_eq!(thermo_state.mass_list.len(), 1); // Should contain one mole fraction entry
+
+        
 
         // Check that the mole fraction's chemical is correctly set
         // assert_eq!(
@@ -207,15 +208,15 @@ mod thermo_tests {
             mass_quantity: anisidine_mass,
         };
 
-        let _therm_obj = ThermoState::new(
+        let therm_obj = ThermoState::new(
             101325.0,
             298.15,
             vec![water_species_pair, anisidine_species_pair],
         );
 
-        // let mass_fraction = _therm_obj
-        //     .mass_frac(&_therm_obj.mass_list[0].chemical_species)
-        //     .unwrap();
+        let mass_fraction = therm_obj
+            .mass_frac(&therm_obj.mass_list[0].chemical_species)
+            .unwrap();
 
         // assert!(
         //     (mass_fraction - 0.2).abs() < 1e-6,


### PR DESCRIPTION
This is a fix addressing #23. A number of lines of code makes HTTP requests to pubchem, which are occasionally denied. This causes stochasticity in the tests. Instead, the results of these requests should be cached locally and used for testing. Avoid calling pubchem functions, such as `.cids()`